### PR TITLE
Fix: Correctly handle file extension and MIME type in download tool

### DIFF
--- a/tools/utils/download_utils.py
+++ b/tools/utils/download_utils.py
@@ -1,5 +1,6 @@
 import os
 import re
+import mimetypes
 import tempfile
 import threading
 from collections.abc import Generator
@@ -129,7 +130,18 @@ def download_to_temp(method: str, url: str,
             encoding = response.encoding
             filename = custom_filename or guess_file_name(url, response)
 
-            with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            # Guess the MIME type from the filename if:
+            # 1. content_type is None
+            # 2. content_type is 'application/octet-stream' (generic binary)
+            # 3. custom_filename is provided (override server's content type)
+            if not mime_type or mime_type == 'application/octet-stream' or custom_filename:
+                guessed_type, _ = mimetypes.guess_type(filename)
+                if guessed_type:
+                    mime_type = guessed_type
+
+            custom_file_extension = os.path.splitext(filename)[1] if filename else None
+            # pass suffix to NamedTemporaryFile to ensure the file has the correct extension
+            with tempfile.NamedTemporaryFile(delete=False, suffix=custom_file_extension) as temp_file:
                 file_path = temp_file.name
                 try:
                     # Stream the response content to the temporary file


### PR DESCRIPTION
This PR fixes an issue where the `download` tool would incorrectly return files with a generic extension (e.g., `.bin`) or incorrect MIME type when a `custom_output_filename` was provided or when the server returned a generic `application/octet-stream` Content-Type.

### Changes
- Updated `tools/utils/download_utils.py` to import `mimetypes`.
- Modified `download_to_temp` function to:
    - Use `mimetypes.guess_type` to determine the correct MIME type based on the filename if the server-provided type is generic or if a custom filename is forced.
    - Ensure `tempfile.NamedTemporaryFile` uses the correct file suffix extracted from the filename.

### Motivation
When using the download tool with a specific filename (e.g., `report.xlsx`), users expect the downstream system to recognize it as an Excel file. Previously, if the server returned `application/octet-stream`, Dify might treat it as a binary file `.bin`, causing issues in subsequent processing steps. This fix ensures the MIME type and file extension align with the user's intent.

### Testing
- Verified with local reproduction script.
- Verified that `custom_output_filename` correctly sets the file extension.